### PR TITLE
Make sure the window doesn't hang around in IDLE

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,4 +87,4 @@ if __name__ == "__main__":
     # Let's the game start!
     main_loop(scene_manager, main_screen, pygame.time.Clock())
 
-    raise SystemExit
+    pygame.quit()


### PR DESCRIPTION
I added in a pygame.quit() so the window closes when the program execution ends on IDLE.

I also got rid of the `raise SystemExit`, because I don't believe it's needed, as the program execution stops right after it.