### PR TITLE
Fixed the bug of entity displacement when load from save.

### DIFF
--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -318,7 +318,16 @@ class LevelScene(Scene):
             # Game is loaded from a save (data)
             from_save = True
             gap_x, gap_y = (0, 0)
-            self.players.extend(loader.load_players(self.data))
+            if (self.map["width"] / TILE_SIZE) % 2 == 1:
+                # If the number of columns is odd, calibrate the x-axis coordinates
+                # Translate the x-coordinate half TILE_SIZE to the right
+                # TODO: Check whether the sign of the following formula is correct.
+                gap_x = 0.5 * TILE_SIZE
+            if (self.map["height"] / TILE_SIZE) % 2 == 1:
+                # If the number of rows is odd, calibrate the y-axis coordinates
+                # Translate the y-coordinate half TILE_SIZE downward
+                gap_y = 0.5 * TILE_SIZE
+            self.players.extend(loader.load_players(self.data, gap_x, gap_y))
             self.escaped_players = loader.load_escaped_players(self.data)
             self.entities.update(
                 loader.load_all_entities_from_save(self.data, gap_x, gap_y)

--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -318,12 +318,12 @@ class LevelScene(Scene):
             # Game is loaded from a save (data)
             from_save = True
             gap_x, gap_y = (0, 0)
-            if (self.map["width"] / TILE_SIZE) % 2 == 1:
+            if (self.map["width"] // TILE_SIZE) % 2 == 1:
                 # If the number of columns is odd, calibrate the x-axis coordinates
                 # Translate the x-coordinate half TILE_SIZE to the right
                 # TODO: Check whether the sign of the following formula is correct.
                 gap_x = 0.5 * TILE_SIZE
-            if (self.map["height"] / TILE_SIZE) % 2 == 1:
+            if (self.map["height"] // TILE_SIZE) % 2 == 1:
                 # If the number of rows is odd, calibrate the y-axis coordinates
                 # Translate the y-coordinate half TILE_SIZE downward
                 gap_y = 0.5 * TILE_SIZE

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -1078,10 +1078,12 @@ def load_player(player_element, from_save, gap_x=0, gap_y=0):
     return player
 
 
-def load_players(data, gap_x, gap_y):
+def load_players(data, gap_x=0, gap_y=0):
     """
 
     :param data:
+    :param gap_x, default 0:
+    :param gap_y, default 0:
     :return:
     """
     players = []

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -971,11 +971,13 @@ def load_events(events_el, gap_x, gap_y):
     return events
 
 
-def load_player(player_element, from_save):
+def load_player(player_element, from_save, gap_x=0, gap_y=0):
     """
 
     :param player_element:
     :param from_save:
+    :param gap_x, default value 0:
+    :param gap_y, default value 0:
     :return:
     """
     name = player_element.find("name").text.strip()
@@ -1060,8 +1062,8 @@ def load_player(player_element, from_save):
     player.hit_points = current_hp
     if from_save:
         position = (
-            int(player_element.find("position/x").text.strip()) * TILE_SIZE,
-            int(player_element.find("position/y").text.strip()) * TILE_SIZE,
+            int(player_element.find("position/x").text.strip()) * TILE_SIZE + gap_x,
+            int(player_element.find("position/y").text.strip()) * TILE_SIZE + gap_y,
         )
         player.position = position
         state = player_element.find("turnFinished").text.strip()
@@ -1076,7 +1078,7 @@ def load_player(player_element, from_save):
     return player
 
 
-def load_players(data):
+def load_players(data, gap_x, gap_y):
     """
 
     :param data:
@@ -1084,7 +1086,7 @@ def load_players(data):
     """
     players = []
     for player_element in data.findall("players/player"):
-        players.append(load_player(player_element, True))
+        players.append(load_player(player_element, True, gap_x, gap_y))
     return players
 
 


### PR DESCRIPTION
When the number of rows or columns of the map is odd, the coordinates of the entity should be translated to correct.
Solved well when the number of the rows of the map is odd. 
Didn't test when the number of the columns of the map is odd. As I dont really know how to edit the map, I cannot check this myself. For insurance, I added a TODO in  level_scene.py, to remind people to check.