### PR TITLE
Fix bug that game crush loading level3

### DIFF
--- a/saves/options.xml
+++ b/saves/options.xml
@@ -1,5 +1,5 @@
 <options>
-    <language>zh_cn</language>
+    <language>en</language>
     <move_speed>4</move_speed>
     <screen_size>1</screen_size>
 </options>

--- a/saves/options.xml
+++ b/saves/options.xml
@@ -1,5 +1,5 @@
 <options>
-    <language>en</language>
+    <language>zh_cn</language>
     <move_speed>4</move_speed>
     <screen_size>1</screen_size>
 </options>

--- a/src/services/global_foes.py
+++ b/src/services/global_foes.py
@@ -1,0 +1,9 @@
+from src.game_entities.foe import Foe
+
+foes_by_mission: dict[str, list[Foe]] = {}
+
+def link_foe_to_mission(foe: Foe, mission_id: str) -> None:
+    if mission_id not in foes_by_mission:
+        foes_by_mission[mission_id] = []
+    foes_by_mission[mission_id].append(foe)
+

--- a/src/services/load_from_tmx_manager.py
+++ b/src/services/load_from_tmx_manager.py
@@ -22,16 +22,9 @@ from src.game_entities.portal import Portal
 from src.game_entities.shop import Shop
 from src.gui.position import Position
 from src.services import load_from_xml_manager as xml_loader
+from src.services.global_foes import foes_by_mission, link_foe_to_mission
 
 objective_tile_by_mission: dict[str, list[Objective]] = {}
-foes_by_mission: dict[str, list[Foe]] = {}
-
-
-def _link_foe_to_mission(foe: Foe, mission_id: str) -> None:
-    if mission_id not in foes_by_mission:
-        foes_by_mission[mission_id] = []
-    foes_by_mission[mission_id].append(foe)
-
 
 def _get_object_position(
     tile_object: TiledObject, horizontal_gap: int, vertical_gap: int
@@ -191,7 +184,7 @@ def load_foes(
             foes.append(foe)
 
             if mission_target:
-                _link_foe_to_mission(foe, mission_target)
+                link_foe_to_mission(foe, mission_target)
 
     return foes
 

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -38,7 +38,8 @@ skills_data = {}
 RACES_DATA_PATH = "data/races.xml"
 CLASSES_DATA_PATH = "data/classes.xml"
 
-foes_by_mission: dict[str, list[Foe]] = {}
+from src.services.global_foes import foes_by_mission, link_foe_to_mission
+# foes_by_mission: dict[str, list[Foe]] = {}
 
 
 def load_races() -> dict[str, dict[str, any]]:
@@ -486,10 +487,10 @@ def load_ally(name: str, position: Position) -> Character:
     return loaded_ally
 
 
-def _link_foe_to_mission(foe: Foe, mission_id: str) -> None:
-    if mission_id not in foes_by_mission:
-        foes_by_mission[mission_id] = []
-    foes_by_mission[mission_id].append(foe)
+# def _link_foe_to_mission(foe: Foe, mission_id: str) -> None:
+#     if mission_id not in foes_by_mission:
+#         foes_by_mission[mission_id] = []
+#     foes_by_mission[mission_id].append(foe)
 
 
 def load_foe_from_save(foe_element, gap_x, gap_y):
@@ -597,7 +598,7 @@ def load_foe_from_save(foe_element, gap_x, gap_y):
     loaded_foe.earn_xp(experience)
 
     if mission_target is not None:
-        _link_foe_to_mission(loaded_foe, mission_target)
+        link_foe_to_mission(loaded_foe, mission_target)
 
     return loaded_foe
 

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -486,13 +486,6 @@ def load_ally(name: str, position: Position) -> Character:
 
     return loaded_ally
 
-
-# def _link_foe_to_mission(foe: Foe, mission_id: str) -> None:
-#     if mission_id not in foes_by_mission:
-#         foes_by_mission[mission_id] = []
-#     foes_by_mission[mission_id].append(foe)
-
-
 def load_foe_from_save(foe_element, gap_x, gap_y):
     """
 

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -39,7 +39,6 @@ RACES_DATA_PATH = "data/races.xml"
 CLASSES_DATA_PATH = "data/classes.xml"
 
 from src.services.global_foes import foes_by_mission, link_foe_to_mission
-# foes_by_mission: dict[str, list[Foe]] = {}
 
 
 def load_races() -> dict[str, dict[str, any]]:


### PR DESCRIPTION
Through a global dict `foes_by_missions ` initialized and altered in new-developed file `global_foes.py`, conflict caused by redefintion of `foes_by_missions` in `load_from_tmx_manager.py` and `load_from_xml_manager.py` is solved successfully.