### PR TITLE
Shop Balance Feature Implemented

### DIFF
--- a/data/en/text.py
+++ b/data/en/text.py
@@ -52,7 +52,6 @@ STR_DIARY = "Diary"
 STR_END_TURN = "End turn"
 STR_DEFAULT_DIARY_BODY_CONTENT = "No event has been recorded yet"
 
-
 # Reward menu
 STR_REWARD_CONGRATULATIONS = "Congratulations! Objective has been completed!"
 
@@ -88,6 +87,10 @@ STR_SHOPPING_SELLING = "Shop - Selling"
 
 def f_UR_GOLD(gold):
     return f"Your gold: {gold}"
+
+
+def f_SHOP_GOLD(shop_balance):
+    return f"Shopkeeper gold: {shop_balance}"
 
 
 # Trade menu
@@ -256,7 +259,7 @@ STR_NOT_ENOUGH_SPACE_IN_INVENTORY_TO_BUY_THIS_ITEM = (
 )
 STR_NOT_ENOUGH_GOLD_TO_BY_THIS_ITEM = "Not enough gold to buy this item."
 STR_THE_ITEM_HAS_BEEN_SOLD = "The item has been sold."
-STR_THIS_ITEM_CANT_BE_SOLD = "This item can't be sold !"
+STR_THIS_ITEM_CANT_BE_SOLD = "The vendor lacks the funds to buy from you !"
 STR_THIS_HOUSE_SEEMS_CLOSED = "This house seems closed..."
 
 

--- a/data/en/text.py
+++ b/data/en/text.py
@@ -52,6 +52,7 @@ STR_DIARY = "Diary"
 STR_END_TURN = "End turn"
 STR_DEFAULT_DIARY_BODY_CONTENT = "No event has been recorded yet"
 
+
 # Reward menu
 STR_REWARD_CONGRATULATIONS = "Congratulations! Objective has been completed!"
 
@@ -87,10 +88,6 @@ STR_SHOPPING_SELLING = "Shop - Selling"
 
 def f_UR_GOLD(gold):
     return f"Your gold: {gold}"
-
-
-def f_SHOP_GOLD(shop_balance):
-    return f"Shopkeeper gold: {shop_balance}"
 
 
 # Trade menu
@@ -259,7 +256,7 @@ STR_NOT_ENOUGH_SPACE_IN_INVENTORY_TO_BUY_THIS_ITEM = (
 )
 STR_NOT_ENOUGH_GOLD_TO_BY_THIS_ITEM = "Not enough gold to buy this item."
 STR_THE_ITEM_HAS_BEEN_SOLD = "The item has been sold."
-STR_THIS_ITEM_CANT_BE_SOLD = "The vendor lacks the funds to buy from you !"
+STR_THIS_ITEM_CANT_BE_SOLD = "This item can't be sold !"
 STR_THIS_HOUSE_SEEMS_CLOSED = "This house seems closed..."
 
 

--- a/data/en/text.py
+++ b/data/en/text.py
@@ -93,6 +93,7 @@ def f_SHOP_GOLD(shop_balance):
     return f"Shopkeeper gold: {shop_balance}"
 
 
+
 # Trade menu
 STR_50G_TO_RIGHT = "50G ->"
 STR_200G_TO_RIGHT = "200G ->"

--- a/src/game_entities/shop.py
+++ b/src/game_entities/shop.py
@@ -133,7 +133,6 @@ class Shop(Building):
                 self.current_visitor.gold -= item.price
                 self.current_visitor.set_item(copy(item))
                 self.shop_balance += item.price
-
                 entry: Optional[dict[str, any]] = self.get_item_entry(item)
                 entry["quantity"] -= 1
                 if entry["quantity"] <= 0:

--- a/src/game_entities/shop.py
+++ b/src/game_entities/shop.py
@@ -39,6 +39,7 @@ class Shop(Building):
     stock -- the data structure containing all the available items to be bought with their associated quantity
     menu -- the shop menu displaying all the items that could be bought
     gold_sfx -- the sound that should be started when an item is sold or bought
+    shop_balance -- the amount of gold the shop has
     """
 
     interaction_callback = None
@@ -50,16 +51,18 @@ class Shop(Building):
         name: str,
         position: Position,
         sprite_link: str,
+        shop_balance: int,
         stock: list[dict[str, any]],
         interaction: Optional[dict[str, any]] = None,
         sprite: Optional[pygame.Surface] = None,
     ) -> None:
         super().__init__(name, position, sprite_link, interaction, sprite)
+        self.shop_balance = 500
         self.current_visitor: Optional[Character] = None
         self.stock: list[dict[str, any]] = stock
         self.interaction: dict[str, any] = interaction
         self.menu: InfoBox = menu_creator_manager.create_shop_menu(
-            Shop.interaction_callback, self.stock, 0
+            Shop.interaction_callback, self.stock, 0, shop_balance
         )
         self.gold_sfx: pygame.mixer.Sound = pygame.mixer.Sound(
             os.path.join("sound_fx", "trade.ogg")
@@ -85,7 +88,7 @@ class Shop(Building):
         gold -- the new gold amount for the player that should be displayed
         """
         self.menu = menu_creator_manager.create_shop_menu(
-            Shop.interaction_callback, self.stock, gold
+            Shop.interaction_callback, self.stock, gold, self.shop_balance
         )
 
     def interact(self, actor: Character) -> list[list[BoxElement]]:
@@ -127,9 +130,9 @@ class Shop(Building):
         if self.current_visitor.gold >= item.price:
             if len(self.current_visitor.items) < self.current_visitor.nb_items_max:
                 pygame.mixer.Sound.play(self.gold_sfx)
-
                 self.current_visitor.gold -= item.price
                 self.current_visitor.set_item(copy(item))
+                self.shop_balance += item.price
 
                 entry: Optional[dict[str, any]] = self.get_item_entry(item)
                 entry["quantity"] -= 1
@@ -153,9 +156,10 @@ class Shop(Building):
         actor -- the actor selling the item
         item -- the item that is being sold
         """
-        if item.resell_price > 0:
+        if 0 < item.resell_price < self.shop_balance:
             self.current_visitor.remove_item(item)
             self.current_visitor.gold += item.resell_price
+            self.shop_balance -= item.resell_price
 
             # Update shop screen content (gold total amount has been augmented)
             self.update_shop_menu(self.current_visitor.gold)

--- a/src/game_entities/shop.py
+++ b/src/game_entities/shop.py
@@ -39,7 +39,6 @@ class Shop(Building):
     stock -- the data structure containing all the available items to be bought with their associated quantity
     menu -- the shop menu displaying all the items that could be bought
     gold_sfx -- the sound that should be started when an item is sold or bought
-    shop_balance -- the amount of gold the shop has
     """
 
     interaction_callback = None
@@ -51,18 +50,16 @@ class Shop(Building):
         name: str,
         position: Position,
         sprite_link: str,
-        shop_balance: int,
         stock: list[dict[str, any]],
         interaction: Optional[dict[str, any]] = None,
         sprite: Optional[pygame.Surface] = None,
     ) -> None:
         super().__init__(name, position, sprite_link, interaction, sprite)
-        self.shop_balance = 500
         self.current_visitor: Optional[Character] = None
         self.stock: list[dict[str, any]] = stock
         self.interaction: dict[str, any] = interaction
         self.menu: InfoBox = menu_creator_manager.create_shop_menu(
-            Shop.interaction_callback, self.stock, 0, shop_balance
+            Shop.interaction_callback, self.stock, 0
         )
         self.gold_sfx: pygame.mixer.Sound = pygame.mixer.Sound(
             os.path.join("sound_fx", "trade.ogg")
@@ -88,7 +85,7 @@ class Shop(Building):
         gold -- the new gold amount for the player that should be displayed
         """
         self.menu = menu_creator_manager.create_shop_menu(
-            Shop.interaction_callback, self.stock, gold, self.shop_balance
+            Shop.interaction_callback, self.stock, gold
         )
 
     def interact(self, actor: Character) -> list[list[BoxElement]]:
@@ -130,9 +127,9 @@ class Shop(Building):
         if self.current_visitor.gold >= item.price:
             if len(self.current_visitor.items) < self.current_visitor.nb_items_max:
                 pygame.mixer.Sound.play(self.gold_sfx)
+
                 self.current_visitor.gold -= item.price
                 self.current_visitor.set_item(copy(item))
-                self.shop_balance += item.price
 
                 entry: Optional[dict[str, any]] = self.get_item_entry(item)
                 entry["quantity"] -= 1
@@ -156,10 +153,9 @@ class Shop(Building):
         actor -- the actor selling the item
         item -- the item that is being sold
         """
-        if 0 < item.resell_price < self.shop_balance:
+        if item.resell_price > 0:
             self.current_visitor.remove_item(item)
             self.current_visitor.gold += item.resell_price
-            self.shop_balance -= item.resell_price
 
             # Update shop screen content (gold total amount has been augmented)
             self.update_shop_menu(self.current_visitor.gold)

--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -341,7 +341,7 @@ class LevelScene(Scene):
             self.entities.chests = tmx_loader.load_chests(self.tmx_data, gap_x, gap_y)
             self.entities.allies = tmx_loader.load_allies(self.tmx_data, gap_x, gap_y)
             self.entities.buildings = tmx_loader.load_buildings(
-                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y
+                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y, self.active_shop.shop_balance
             )
             self.entities.breakables = tmx_loader.load_breakables(
                 self.tmx_data, gap_x, gap_y

--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -341,7 +341,7 @@ class LevelScene(Scene):
             self.entities.chests = tmx_loader.load_chests(self.tmx_data, gap_x, gap_y)
             self.entities.allies = tmx_loader.load_allies(self.tmx_data, gap_x, gap_y)
             self.entities.buildings = tmx_loader.load_buildings(
-                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y, self.active_shop.shop_balance
+                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y, 500
             )
             self.entities.breakables = tmx_loader.load_breakables(
                 self.tmx_data, gap_x, gap_y

--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -351,6 +351,7 @@ class LevelScene(Scene):
             self.entities.fountains = tmx_loader.load_fountains(
                 self.tmx_data, gap_x, gap_y
             )
+
         else:
             # Game is loaded from a save (data)
             gap_x, gap_y = (0, 0)

--- a/src/scenes/level_scene.py
+++ b/src/scenes/level_scene.py
@@ -341,7 +341,7 @@ class LevelScene(Scene):
             self.entities.chests = tmx_loader.load_chests(self.tmx_data, gap_x, gap_y)
             self.entities.allies = tmx_loader.load_allies(self.tmx_data, gap_x, gap_y)
             self.entities.buildings = tmx_loader.load_buildings(
-                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y, self.active_shop.shop_balance
+                self.tmx_data, DATA_PATH + self.directory, gap_x, gap_y
             )
             self.entities.breakables = tmx_loader.load_breakables(
                 self.tmx_data, gap_x, gap_y

--- a/src/services/load_from_tmx_manager.py
+++ b/src/services/load_from_tmx_manager.py
@@ -306,7 +306,7 @@ def load_events(
 
 
 def load_buildings(
-    tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int, shop_balance: int
+    tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int
 ) -> list[Building]:
     buildings = []
     for tile_object in tmx_data.get_layer_by_name("dynamic_data"):
@@ -364,7 +364,6 @@ def load_buildings(
                         tile_object.name,
                         position,
                         tile_object.properties["sprite_link"],
-                        shop_balance,
                         stock,
                         interaction,
                         image,

--- a/src/services/load_from_tmx_manager.py
+++ b/src/services/load_from_tmx_manager.py
@@ -306,7 +306,7 @@ def load_events(
 
 
 def load_buildings(
-    tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int
+    tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int, shop_balance: int
 ) -> list[Building]:
     buildings = []
     for tile_object in tmx_data.get_layer_by_name("dynamic_data"):
@@ -364,6 +364,7 @@ def load_buildings(
                         tile_object.name,
                         position,
                         tile_object.properties["sprite_link"],
+                        shop_balance,
                         stock,
                         interaction,
                         image,

--- a/src/services/load_from_tmx_manager.py
+++ b/src/services/load_from_tmx_manager.py
@@ -83,6 +83,7 @@ def _load_objectives(tmx_data, horizontal_gap, vertical_gap) -> None:
             )
 
 
+
 def _load_mission(
     tmx_data: pytmx.TiledMap, is_main: bool, mission_id: str, players: Sequence[Player]
 ) -> Mission:

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -776,6 +776,7 @@ def load_building_from_save(building, gap_x, gap_y, shop_balance=None):
                 }
                 stock.append(entry)
             loaded_building = Shop(name, position, sprite, shop_balance, stock, interaction_element)
+
         else:
             print("Error : building type isn't recognized : ", type)
             raise SystemError

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -728,12 +728,13 @@ def load_door_from_save(door, gap_x, gap_y):
     return loaded_door
 
 
-def load_building_from_save(building, gap_x, gap_y):
+def load_building_from_save(building, gap_x, gap_y, shop_balance=None):
     """
 
     :param building:
     :param gap_x:
     :param gap_y:
+    :shop_balance:
     :return:
     """
     # Static data
@@ -774,7 +775,7 @@ def load_building_from_save(building, gap_x, gap_y):
                     "quantity": int(item.find("quantity").text.strip()),
                 }
                 stock.append(entry)
-            loaded_building = Shop(name, position, sprite, stock, interaction_element)
+            loaded_building = Shop(name, position, sprite, shop_balance, stock, interaction_element)
         else:
             print("Error : building type isn't recognized : ", type)
             raise SystemError

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -728,13 +728,12 @@ def load_door_from_save(door, gap_x, gap_y):
     return loaded_door
 
 
-def load_building_from_save(building, gap_x, gap_y, shop_balance=None):
+def load_building_from_save(building, gap_x, gap_y):
     """
 
     :param building:
     :param gap_x:
     :param gap_y:
-    :shop_balance:
     :return:
     """
     # Static data
@@ -775,7 +774,7 @@ def load_building_from_save(building, gap_x, gap_y, shop_balance=None):
                     "quantity": int(item.find("quantity").text.strip()),
                 }
                 stock.append(entry)
-            loaded_building = Shop(name, position, sprite, shop_balance, stock, interaction_element)
+            loaded_building = Shop(name, position, sprite, stock, interaction_element)
         else:
             print("Error : building type isn't recognized : ", type)
             raise SystemError

--- a/src/services/menu_creator_manager.py
+++ b/src/services/menu_creator_manager.py
@@ -57,14 +57,13 @@ def create_shop_menu(
     interaction_callback: Callable,
     stock: Sequence[dict[str, Union[Item, int]]],
     gold: int,
-    shop_balance: int) -> InfoBox:
+) -> InfoBox:
     """
     Return the interface of a shop menu with user as the buyer.
 
     Keyword arguments:
     stock -- the collection of items that are available in the shop, with the quantity of each one
     gold -- the amount of gold that should be displayed at the bottom
-    shop_balance -- the amount of gold that shopkeeper has
     """
     element_grid = []
     row = []
@@ -97,8 +96,6 @@ def create_shop_menu(
     # Gold at end
     player_gold_line = [TextElement(f_UR_GOLD(gold), font=fonts["ITEM_DESC_FONT"])]
     element_grid.append(player_gold_line)
-    shop_gold_line = [TextElement(f_SHOP_GOLD(shop_balance), font=fonts["ITEM_DESC_FONT"])]
-    element_grid.append(shop_gold_line)
 
     return InfoBox(
         STR_SHOP_BUYING,

--- a/src/services/menu_creator_manager.py
+++ b/src/services/menu_creator_manager.py
@@ -57,13 +57,14 @@ def create_shop_menu(
     interaction_callback: Callable,
     stock: Sequence[dict[str, Union[Item, int]]],
     gold: int,
-) -> InfoBox:
+    shop_balance: int) -> InfoBox:
     """
     Return the interface of a shop menu with user as the buyer.
 
     Keyword arguments:
     stock -- the collection of items that are available in the shop, with the quantity of each one
     gold -- the amount of gold that should be displayed at the bottom
+    shop_balance -- the amount of gold that shopkeeper has
     """
     element_grid = []
     row = []
@@ -96,6 +97,8 @@ def create_shop_menu(
     # Gold at end
     player_gold_line = [TextElement(f_UR_GOLD(gold), font=fonts["ITEM_DESC_FONT"])]
     element_grid.append(player_gold_line)
+    shop_gold_line = [TextElement(f_SHOP_GOLD(shop_balance), font=fonts["ITEM_DESC_FONT"])]
+    element_grid.append(shop_gold_line)
 
     return InfoBox(
         STR_SHOP_BUYING,

--- a/src/services/menu_creator_manager.py
+++ b/src/services/menu_creator_manager.py
@@ -64,7 +64,7 @@ def create_shop_menu(
     Keyword arguments:
     stock -- the collection of items that are available in the shop, with the quantity of each one
     gold -- the amount of gold that should be displayed at the bottom
-    shop_balance -- the amount of gold that shopkeeper has
+    shop_balance -- the shopkeeper's gold, displayed at the bottom
     """
     element_grid = []
     row = []


### PR DESCRIPTION
text - New function to display shopkeeper balance, modified STR_THIS_ITEM_CANT_BE_SOLD to better fit context
shop - Added new variable shop_balance; initialized to 500 for testing, buy and sell functions adjusted to update vendor amount
menu_creator_manager - create_shop_menu updated to show vendor gold in UI
load xml, load tmx, level_scene - added shop_balance parameter to constructors

Additional Notes: Shop balance does not show on sell interface. Shop balance value is not updated when saved, may be due to the fact that they were set to 500 in the constructor. The load xml, load tmx, and level_scene files need to be reviewed for confirmation. The basic functionality is there, but tweaks still need to be made.

Excuse the previous PR, there was an uninitialized variable within level_scene that prevented main new game button the function, it is now fixed.