### PR TITLE
Debug errors related tests/test_start_screen

### DIFF
--- a/tests/test_start_screen.py
+++ b/tests/test_start_screen.py
@@ -83,8 +83,6 @@ class TestStartScreen(unittest.TestCase):
         center_x = int(center_x_base * scale_x)
         center_y = int(center_y_base * scale_y)
         position = Position(center_x, center_y)
-        # Print pos in case of test failure
-        print(f"Generated position: {position}")
         return position
 
     def setUp(self):


### PR DESCRIPTION
Here I attempt to address two assertion errors I encountered in tests/test_start_screen. 

1. The test had assertion errors related to file path mismatch. I updated it to load data saved in save_0.xml. Not sure if that is the correct solution.

2. Fixed another bug related to coordinate mismatch. I fixed this by re-scaling the coordinates according to whatever size the OS forces the window to. Also sample the center of the desired region vs a random coordinate. 