### PR TITLE
fix: hide lock-picking option for already opened chests

### DIFF
--- a/src/services/menu_creator_manager.py
+++ b/src/services/menu_creator_manager.py
@@ -563,7 +563,7 @@ def create_player_menu(
                         ],
                     )
                     chest_option = True
-                if "lock_picking" in player.skills and not pick_lock_option:
+                if "lock_picking" in player.skills and not pick_lock_option and not entity.opened:
                     grid_elements.insert(
                         0,
                         [


### PR DESCRIPTION
I fixed issue #133 by adding an additional condition to prevent the "pick_lock" button from appearing when the chest is already open.