### PR TITLE
Implement shop money: TMX support, save/load persistence

### DIFF
--- a/maps/level_0/map.tmx
+++ b/maps/level_0/map.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.4" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="7" nextobjectid="152">
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="16" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="7" nextobjectid="152">
  <editorsettings>
   <export format="tmx"/>
  </editorsettings>
@@ -138,6 +138,7 @@
     <property name="item_3_name" value="scroll_of_knowledge"/>
     <property name="item_3_quantity" type="int" value="3"/>
     <property name="kind" value="shop"/>
+    <property name="money" type="int" value="500"/>
     <property name="number_items" type="int" value="4"/>
     <property name="sprite_link" value="imgs/houses/shop.png"/>
    </properties>

--- a/maps/level_3/map.tmx
+++ b/maps/level_3/map.tmx
@@ -125,6 +125,7 @@
     <property name="kind" value="shop"/>
     <property name="number_items" type="int" value="4"/>
     <property name="sprite_link" value="imgs/houses/shop.png"/>
+    <property name="money" type="int" value="500"/>
    </properties>
   </object>
   <object id="58" name="apothecary" type="building" gid="6103" x="544" y="224" width="32" height="32">
@@ -138,6 +139,7 @@
     <property name="kind" value="shop"/>
     <property name="number_items" type="int" value="3"/>
     <property name="sprite_link" value="imgs/houses/tavern.png"/>
+    <property name="money" type="int" value="500"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/game_entities/shop.py
+++ b/src/game_entities/shop.py
@@ -180,6 +180,10 @@ class Shop(Building):
         # Specify nature
         nature: etree.SubElement = etree.SubElement(tree, "type")
         nature.text = "shop"
+        
+         # Save the current shop balance
+        money: etree.SubElement = etree.SubElement(tree, "money")
+        money.text = str(self.shop_balance)
 
         # Specify content
         items: etree.SubElement = etree.SubElement(tree, "items")

--- a/src/services/load_from_tmx_manager.py
+++ b/src/services/load_from_tmx_manager.py
@@ -307,7 +307,7 @@ def load_events(
 
 
 def load_buildings(
-        tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int, shop_balance: int
+        tmx_data: pytmx.TiledMap, directory: str, horizontal_gap: int, vertical_gap: int
 ) -> list[Building]:
     buildings = []
     for tile_object in tmx_data.get_layer_by_name("dynamic_data"):
@@ -360,12 +360,13 @@ def load_buildings(
                         "quantity": tile_object.properties[f"item_{item_id}_quantity"],
                     }
                     stock.append(item_entry)
+                shop_money = tile_object.properties.get("money", 500)
                 buildings.append(
                     Shop(
                         tile_object.name,
                         position,
                         tile_object.properties["sprite_link"],
-                        shop_balance,
+                        shop_money,
                         stock,
                         interaction,
                         image,

--- a/src/services/load_from_xml_manager.py
+++ b/src/services/load_from_xml_manager.py
@@ -773,8 +773,13 @@ def load_building_from_save(building, gap_x, gap_y, shop_balance=500):
                     "quantity": int(item.find("quantity").text.strip()),
                 }
                 stock.append(entry)
-            loaded_building = Shop(name, position, sprite, shop_balance, stock, interaction_element)
-
+            money_element = building.find("money")
+            money = (
+                int(money_element.text.strip())
+                if money_element is not None
+                else shop_balance
+            )
+            loaded_building = Shop(name, position, sprite, money, stock, interaction_element)
         else:
             print("Error : building type isn't recognized : ", type)
             raise SystemError


### PR DESCRIPTION
#76 
+)
Added a money property to shop objects in the TMX maps (level 0 and 3).

Updated load_from_tmx_manager.py to read the shop’s money directly from the map.

Updated Shop.save() to include the current shop money in the save file.

Updated load_from_xml_manager.py to load the shop’s money from saved data.


-)

The shop balance still needs to be displayed in the sell interface (not part of this PR).