### PR TITLE
Replace flake8 + pylint with ruff for linting

### DIFF
--- a/.github/workflows/verify-and-test-game.yml
+++ b/.github/workflows/verify-and-test-game.yml
@@ -26,17 +26,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install pylint pylint-exit
-      - name: Lint with flake8
+          pip install ruff
+      - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Lint with Pylint
-        run: |
-          pylint main.py src --extension-pkg-whitelist=pygame,lxml --max-line-length=120 || pylint-exit $?
+          ruff check . --select=E9,F63,F7,F82 --output-format=full
+          # exit-zero treats all other errors as warnings
+          ruff check . --exit-zero --output-format=concise --statistics
   test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -61,4 +57,3 @@ jobs:
         env:
           SDL_VIDEODRIVER: dummy
           SDL_AUDIODRIVER: dummy
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,22 @@ dependencies = [
 
 [tool.uv]
 package = false
+
+[tool.ruff]
+line-length = 127
+target-version = "py313"
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "C90",    # mccabe complexity
+]
+ignore = [
+    "F405",   # may be undefined from star import - known pattern in this codebase
+    "F403",   # star imports - known pattern in this codebase
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10


### PR DESCRIPTION
Closes #156

## Summary

- Replaces `flake8` and `pylint` with `ruff` in the CI workflow
- Adds `[tool.ruff]` configuration to `pyproject.toml`

## How ruff replicates the old linting

### CI workflow changes

- **First ruff command** (`ruff check . --select=E9,F63,F7,F82 --output-format=full`) replaces `flake8 . --select=E9,F63,F7,F82 --show-source` — same rule codes, same purpose (fail on syntax errors / undefined names).
- **Second ruff command** (`ruff check . --exit-zero --output-format=concise --statistics`) replaces the second flake8 pass. Line length and complexity limits are now in `pyproject.toml` so they apply automatically.
- **Pylint removed** — its useful checks (pycodestyle, pyflakes, complexity) are covered by ruff's `E`, `W`, `F`, and `C90` rule sets. Pylint was already non-blocking (`pylint-exit` swallowed failures).

### pyproject.toml settings

| Setting | What it does | Replaces |
|---|---|---|
| `line-length = 127` | Max line length | `flake8 --max-line-length=127` |
| `target-version = "py313"` | Version-appropriate checks | Matches existing `requires-python = ">=3.13"` |
| `select = ["E","W","F","C90"]` | pycodestyle + pyflakes + mccabe | flake8 defaults + `--max-complexity` flag |
| `ignore = ["F403","F405"]` | Allow star imports | Codebase uses star imports as a known pattern |
| `max-complexity = 10` | Cyclomatic complexity cap | `flake8 --max-complexity=10` |

## Test plan

- [x] CI "Lint" job passes on this branch
- [ ] `ruff check .` runs locally with no unexpected errors
